### PR TITLE
Add hostname for RabbitMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - PHP version selection
 - TLS support with mkcert
+- RabbitMQ hostname to preserve data across restarts
 
 ## [0.2.0]
 

--- a/project-template/base.yml
+++ b/project-template/base.yml
@@ -62,6 +62,7 @@ services:
 
   magento_messagequeue:
     image: "rabbitmq:management-alpine"
+    hostname: "rabbitmq"
     networks:
       - "magento"
 


### PR DESCRIPTION
As per https://hub.docker.com/_/rabbitmq/, add a hostname to the RabbitMQ container.